### PR TITLE
allow an initial value to be omitted when the type is Optional

### DIFF
--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -82,8 +82,9 @@ extension AssociatedObjectMacro: AccessorMacro {
             return []
         }
 
-        // Initial value required
-        guard let defaultValue = binding.initializer?.value else {
+        let defaultValue = binding.initializer?.value
+        // Initial value required if type is optional
+        if defaultValue == nil && !type.isOptional {
             context.diagnose(AssociatedObjectMacroDiagnostic.requiresInitialValue.diagnose(at: declaration))
             return []
         }
@@ -103,7 +104,7 @@ extension AssociatedObjectMacro: AccessorMacro {
                         self,
                         &Self.__associated_\(identifier)Key
                     ) as? \(type)
-                    ?? \(defaultValue)
+                    ?? \(defaultValue ?? "nil")
                     """
                 }
             ),

--- a/Sources/AssociatedObjectPlugin/Extension/TypeSyntax+.swift
+++ b/Sources/AssociatedObjectPlugin/Extension/TypeSyntax+.swift
@@ -1,0 +1,23 @@
+//
+//  TypeSyntax+.swift
+//
+//
+//  Created by p-x9 on 2023/06/27.
+//  
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension TypeSyntax {
+    var isOptional: Bool {
+        if let optionalType = self.as(OptionalTypeSyntax.self) {
+            return true
+        }
+        if let simpleType = self.as(SimpleTypeIdentifierSyntax.self),
+           simpleType.name.trimmed.text == "Optional" {
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
```swift
@AssociatedObject(.OBJC_ASSOCIATION_COPY_NONATOMIC)
var optionalText: String?
```

```swift
@AssociatedObject(.OBJC_ASSOCIATION_COPY_NONATOMIC)
var optionalText: Optional<String>
```
