### PR TITLE
Format expanded code

### DIFF
--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -161,9 +161,9 @@ extension AssociatedObjectMacro {
             body: CodeBlockSyntax {
                 if let willSet = `willSet`,
                    let body = willSet.body {
-                    let newValue = willSet.parameters?.name.trimmed ?? .identifier("newValue")
                     Self.willSet(
                         type: type,
+                        accessor: willSet,
                         body: body
                     )
 
@@ -186,10 +186,9 @@ extension AssociatedObjectMacro {
 
                 if let didSet = `didSet`,
                    let body = didSet.body {
-                    let oldValue = didSet.parameters?.name.trimmed ?? .identifier("oldValue")
-
                     Self.didSet(
                         type: type,
+                        accessor: didSet,
                         body: body
                     ).with(\.leadingTrivia, .newlines(2))
 
@@ -213,9 +212,12 @@ extension AssociatedObjectMacro {
     /// - Returns: Variable that converts the contents of willSet to a closure
     static func `willSet`(
         type: TypeSyntax,
+        accessor: AccessorDeclSyntax,
         body: CodeBlockSyntax
     ) -> VariableDeclSyntax {
-        VariableDeclSyntax(
+        let newValue = accessor.parameters?.name.trimmed ?? .identifier("newValue")
+
+        return VariableDeclSyntax(
             bindingSpecifier: .keyword(.let),
             bindings: .init() {
                 .init(
@@ -243,7 +245,7 @@ extension AssociatedObjectMacro {
                                     )
                                 },
                                 parameterClause: .init(ClosureShorthandParameterListSyntax() {
-                                    ClosureShorthandParameterSyntax(name: .identifier("newValue"))
+                                    ClosureShorthandParameterSyntax(name: newValue)
                                 })
                             ),
                             statements: .init(body.statements.map(\.trimmed))
@@ -268,9 +270,12 @@ extension AssociatedObjectMacro {
     /// - Returns: Variable that converts the contents of didSet to a closure
     static func `didSet`(
         type: TypeSyntax,
+        accessor: AccessorDeclSyntax,
         body: CodeBlockSyntax
     ) -> VariableDeclSyntax {
-        VariableDeclSyntax(
+        let oldValue = accessor.parameters?.name.trimmed ?? .identifier("oldValue")
+
+        return VariableDeclSyntax(
             bindingSpecifier: .keyword(.let),
             bindings: .init() {
                 .init(
@@ -298,7 +303,7 @@ extension AssociatedObjectMacro {
                                     )
                                 },
                                 parameterClause: .init(ClosureShorthandParameterListSyntax() {
-                                    ClosureShorthandParameterSyntax(name: .identifier("oldValue"))
+                                    ClosureShorthandParameterSyntax(name: oldValue)
                                 })
                             ),
                             statements: .init(body.statements.map(\.trimmed))

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -122,13 +122,13 @@ extension AssociatedObjectMacro {
         AccessorDeclSyntax(
             accessorSpecifier: .keyword(.get),
             body: CodeBlockSyntax {
-                    """
-                    objc_getAssociatedObject(
-                        self,
-                        &Self.__associated_\(identifier)Key
-                    ) as? \(type)
-                    ?? \(defaultValue ?? "nil")
-                    """
+                """
+                objc_getAssociatedObject(
+                    self,
+                    &Self.__associated_\(identifier)Key
+                ) as? \(type)
+                ?? \(defaultValue ?? "nil")
+                """
             }
         )
     }
@@ -149,7 +149,6 @@ extension AssociatedObjectMacro {
                    let body = willSet.body {
                     let newValue = willSet.parameters?.name.trimmed ?? .identifier("newValue")
                     Self.willSet(
-                        accessor: willSet,
                         type: type,
                         body: body
                     )
@@ -176,7 +175,6 @@ extension AssociatedObjectMacro {
                     let oldValue = didSet.parameters?.name.trimmed ?? .identifier("oldValue")
 
                     Self.didSet(
-                        accessor: didSet,
                         type: type,
                         body: body
                     ).with(\.leadingTrivia, .newlines(2))
@@ -188,7 +186,6 @@ extension AssociatedObjectMacro {
     }
 
     static func `willSet`(
-        accessor: AccessorDeclSyntax,
         type: TypeSyntax,
         body: CodeBlockSyntax
     ) -> VariableDeclSyntax {
@@ -232,7 +229,6 @@ extension AssociatedObjectMacro {
     }
 
     static func `didSet`(
-        accessor: AccessorDeclSyntax,
         type: TypeSyntax,
         body: CodeBlockSyntax
     ) -> VariableDeclSyntax {

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -184,7 +184,19 @@ extension AssociatedObjectMacro {
             }
         )
     }
-
+    
+    /// `willSet` closure
+    ///
+    /// Convert a willSet accessor to a closure variable in the following format.
+    /// ```swift
+    /// let `willSet`: (\(type.trimmed)) -> Void = { [self] \(newValue) in
+    ///     \(body.statements.trimmed)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - type: Type of Associated object.
+    ///   - body: Contents of willSet
+    /// - Returns: Variable that converts the contents of willSet to a closure
     static func `willSet`(
         type: TypeSyntax,
         body: CodeBlockSyntax
@@ -228,6 +240,18 @@ extension AssociatedObjectMacro {
         )
     }
 
+    /// `didSet` closure
+    ///
+    /// Convert a didSet accessor to a closure variable in the following format.
+    /// ```swift
+    /// let `didSet`: (\(type.trimmed)) -> Void = { [self] \(oldValue) in
+    ///     \(body.statements.trimmed)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - type: Type of Associated object.
+    ///   - body: Contents of didSet
+    /// - Returns: Variable that converts the contents of didSet to a closure
     static func `didSet`(
         type: TypeSyntax,
         body: CodeBlockSyntax
@@ -270,7 +294,13 @@ extension AssociatedObjectMacro {
             }
         )
     }
-
+    
+    /// Execute willSet closure
+    ///
+    /// ```swift
+    /// willSet(newValue)
+    /// ```
+    /// - Returns: Syntax for executing willSet closure
     static func callWillSet() -> FunctionCallExprSyntax {
         FunctionCallExprSyntax(
             callee: DeclReferenceExprSyntax(baseName: .identifier("willSet")),
@@ -283,7 +313,13 @@ extension AssociatedObjectMacro {
             }
         )
     }
-
+    
+    /// Execute didSet closure
+    ///
+    /// ```swift
+    /// didSet(oldValue)
+    /// ```
+    /// - Returns: Syntax for executing didSet closure
     static func callDidSet() -> FunctionCallExprSyntax {
         FunctionCallExprSyntax(
             callee: DeclReferenceExprSyntax(baseName: .identifier("didSet")),

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -114,6 +114,12 @@ extension AssociatedObjectMacro: AccessorMacro {
 }
 
 extension AssociatedObjectMacro {
+    /// Create the syntax for the `get` accessor after expansion.
+    /// - Parameters:
+    ///   - identifier: Type of Associated object.
+    ///   - type: Type of Associated object.
+    ///   - defaultValue: Syntax of default value
+    /// - Returns: Syntax of `get` accessor after expansion.
     static func getter(
         identifier: TokenSyntax,
         type: TypeSyntax,
@@ -135,6 +141,14 @@ extension AssociatedObjectMacro {
 }
 
 extension AssociatedObjectMacro {
+    /// Create the syntax for the `set` accessor after expansion.
+    /// - Parameters:
+    ///   - identifier: Name of associated object.
+    ///   - type: Type of Associated object.
+    ///   - policy: Syntax of `objc_AssociationPolicy`
+    ///   - `willSet`: `willSet` accessor of the original variable definition.
+    ///   - `didSet`: `didSet` accessor of the original variable definition.
+    /// - Returns: Syntax of `set` accessor after expansion.
     static func setter(
         identifier: TokenSyntax,
         type: TypeSyntax,


### PR DESCRIPTION
```swift
@AssociatedObject(.OBJC_ASSOCIATION_ASSIGN) 
    var test: String = "" {
        willSet {
            print("willSet: new", newValue)
            print(backgroundColor)
        }
        didSet {
            print("didSet: old", oldValue)
        }
    }
```

Old
```swift
get {
    objc_getAssociatedObject(
        self,
        &Self.__associated_testKey
    ) as? String
    ?? ""
}

set {
    let willSet: (String) -> Void = { [self] newValue in
        print("willSet: new", newValue)
                    print(backgroundColor)
    }
willSet(newValue)
    let oldValue = test
    objc_setAssociatedObject(
        self,
        &Self.__associated_testKey,
        newValue,
        .OBJC_ASSOCIATION_ASSIGN
    )
    let didSet: (String) -> Void = { [self] oldValue in
        print("didSet: old", oldValue)
    }
didSet(oldValue)
}
```

New
```swift
get {
    objc_getAssociatedObject(
        self,
        &Self.__associated_testKey
    ) as? String
    ?? ""
}

set {
    let willSet: (String ) -> Void = { [self] newValue in
        print("willSet: new", newValue)
        print(backgroundColor)
    }
    willSet(newValue)

    let oldValue = test
    objc_setAssociatedObject(
        self,
        &Self.__associated_testKey,
        newValue,
        .OBJC_ASSOCIATION_ASSIGN
    )

    let didSet: (String ) -> Void = { [self] oldValue in
        print("didSet: old", oldValue)
    }
    didSet(oldValue)
}
```