### PR TITLE
default value should set to AssociatedObject

### DIFF
--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -146,7 +146,7 @@ extension AssociatedObjectMacro {
                     ) as? \(type.trimmed) {
                         return value
                     }
-                        let value = \(defaultValue.trimmed)
+                        let value: \(type.trimmed) = \(defaultValue.trimmed)
                         objc_setAssociatedObject(
                             self,
                             &Self.__associated_\(identifier.trimmed)Key,

--- a/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
@@ -19,11 +19,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var string: String = "text" {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -51,11 +60,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var int: Int = 5 {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_intKey
-                    ) as? Int
-                    ?? 5
+                    ) as? Int {
+                        return value
+                    }
+                    let value = 5
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_intKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -83,11 +101,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var float: Float = 5.0 {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_floatKey
-                    ) as? Float
-                    ?? 5.0
+                    ) as? Float {
+                        return value
+                    }
+                    let value = 5.0
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_floatKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -115,11 +142,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var double: Double = 5.0 {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_doubleKey
-                    ) as? Double
-                    ?? 5.0
+                    ) as? Double {
+                        return value
+                    }
+                    let value = 5.0
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_doubleKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -147,11 +183,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var string: String = "text" {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_COPY
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -179,11 +224,13 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var string: String? {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String?
-                    ?? nil
+                    ) as? String? {
+                        return value
+                    }
+                    return nil
                 }
                 set {
                     objc_setAssociatedObject(
@@ -211,11 +258,13 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var string: Optional<String> {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? Optional<String>
-                    ?? nil
+                    ) as? Optional<String> {
+                        return value
+                    }
+                    return nil
                 }
                 set {
                     objc_setAssociatedObject(
@@ -243,11 +292,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var bool: Bool = false {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_boolKey
-                    ) as? Bool
-                    ?? false
+                    ) as? Bool {
+                        return value
+                    }
+                    let value = false
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_boolKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -275,11 +333,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var intArray: [Int] = [1, 2, 3] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_intArrayKey
-                    ) as? [Int]
-                    ?? [1, 2, 3]
+                    ) as? [Int] {
+                        return value
+                    }
+                    let value = [1, 2, 3]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_intArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -307,11 +374,13 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var bool: Bool? {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_boolKey
-                    ) as? Bool?
-                    ?? nil
+                    ) as? Bool? {
+                        return value
+                    }
+                    return nil
                 }
                 set {
                     objc_setAssociatedObject(
@@ -339,11 +408,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var dic: [String: String] = ["t": "a"] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_dicKey
-                    ) as? [String: String]
-                    ?? ["t": "a"]
+                    ) as? [String: String] {
+                        return value
+                    }
+                    let value = ["t": "a"]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_dicKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -380,11 +458,20 @@ final class AssociatedObjectTests: XCTestCase {
                     print("willSet: new", newValue)
                 }
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
 
                 set {
@@ -426,11 +513,20 @@ final class AssociatedObjectTests: XCTestCase {
                     print("didSet: old", oldValue)
                 }
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
 
                 set {
@@ -480,11 +576,20 @@ final class AssociatedObjectTests: XCTestCase {
                     print("didSet: old", oldValue)
                 }
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
 
                 set {
@@ -534,11 +639,20 @@ final class AssociatedObjectTests: XCTestCase {
                     print("willSet: new", new)
                 }
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
 
                 set {
@@ -580,11 +694,20 @@ final class AssociatedObjectTests: XCTestCase {
                     print("didSet: old", old)
                 }
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
 
                 set {
@@ -619,11 +742,20 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var string: String = "text" {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String
-                    ?? "text"
+                    ) as? String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .copy(.nonatomic)
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(

--- a/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
@@ -8,7 +8,7 @@ final class AssociatedObjectTests: XCTestCase {
     let macros: [String: Macro.Type] = [
         "AssociatedObject": AssociatedObjectMacro.self
     ]
-
+    
     func testString() throws {
         assertMacroExpansion(
             """
@@ -25,7 +25,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -66,7 +66,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? Int {
                         return value
                     }
-                    let value = 5
+                    let value: Int = 5
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_intKey,
@@ -107,7 +107,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? Float {
                         return value
                     }
-                    let value = 5.0
+                    let value: Float = 5.0
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_floatKey,
@@ -148,7 +148,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? Double {
                         return value
                     }
-                    let value = 5.0
+                    let value: Double = 5.0
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_doubleKey,
@@ -189,7 +189,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -298,7 +298,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? Bool {
                         return value
                     }
-                    let value = false
+                    let value: Bool = false
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_boolKey,
@@ -339,7 +339,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? [Int] {
                         return value
                     }
-                    let value = [1, 2, 3]
+                    let value: [Int] = [1, 2, 3]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_intArrayKey,
@@ -414,7 +414,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? [String: String] {
                         return value
                     }
-                    let value = ["t": "a"]
+                    let value: [String: String] = ["t": "a"]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_dicKey,
@@ -464,7 +464,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -519,7 +519,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -582,7 +582,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -645,7 +645,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -700,7 +700,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -748,7 +748,7 @@ final class AssociatedObjectTests: XCTestCase {
                     ) as? String {
                         return value
                     }
-                    let value = "text"
+                    let value: String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,

--- a/Tests/AssociatedObjectTests/AssociatedTypeDetectionObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedTypeDetectionObjectTests.swift
@@ -32,11 +32,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var int = 10 {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_intKey
-                    ) as? Swift.Int
-                    ?? 10
+                    ) as? Swift.Int {
+                        return value
+                    }
+                    let value = 10
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_intKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -64,11 +73,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var double = 10.0 {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_doubleKey
-                    ) as? Swift.Double
-                    ?? 10.0
+                    ) as? Swift.Double {
+                        return value
+                    }
+                    let value = 10.0
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_doubleKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -96,11 +114,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var string = "text" {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? Swift.String
-                    ?? "text"
+                    ) as? Swift.String {
+                        return value
+                    }
+                    let value = "text"
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -128,11 +155,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var bool = false {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_boolKey
-                    ) as? Swift.Bool
-                    ?? false
+                    ) as? Swift.Bool {
+                        return value
+                    }
+                    let value = false
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_boolKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -163,11 +199,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var intArray = [1, 2, 3] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_intArrayKey
-                    ) as? [Swift.Int]
-                    ?? [1, 2, 3]
+                    ) as? [Swift.Int] {
+                        return value
+                    }
+                    let value = [1, 2, 3]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_intArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -195,11 +240,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var doubleArray = [1.0, 2.0, 3.0] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_doubleArrayKey
-                    ) as? [Swift.Double]
-                    ?? [1.0, 2.0, 3.0]
+                    ) as? [Swift.Double] {
+                        return value
+                    }
+                    let value = [1.0, 2.0, 3.0]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_doubleArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -227,11 +281,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var doubleArray = [1, 1.0, 2, 2.0, 3, 3.0] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_doubleArrayKey
-                    ) as? [Swift.Double]
-                    ?? [1, 1.0, 2, 2.0, 3, 3.0]
+                    ) as? [Swift.Double] {
+                        return value
+                    }
+                    let value = [1, 1.0, 2, 2.0, 3, 3.0]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_doubleArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -259,11 +322,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var boolArray = [true, false] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_boolArrayKey
-                    ) as? [Swift.Bool]
-                    ?? [true, false]
+                    ) as? [Swift.Bool] {
+                        return value
+                    }
+                    let value = [true, false]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_boolArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -291,11 +363,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var stringArray = ["1.0", "2.0", "3.0"] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringArrayKey
-                    ) as? [Swift.String]
-                    ?? ["1.0", "2.0", "3.0"]
+                    ) as? [Swift.String] {
+                        return value
+                    }
+                    let value = ["1.0", "2.0", "3.0"]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -326,11 +407,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var optionalIntArray = [1, 1, nil, 2, 3, nil] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_optionalIntArrayKey
-                    ) as? [Swift.Int?]
-                    ?? [1, 1, nil, 2, 3, nil]
+                    ) as? [Swift.Int?] {
+                        return value
+                    }
+                    let value = [1, 1, nil, 2, 3, nil]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_optionalIntArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -358,11 +448,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var optionalDoubleArray = [1.0, 2.0, 3.0, nil] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_optionalDoubleArrayKey
-                    ) as? [Swift.Double?]
-                    ?? [1.0, 2.0, 3.0, nil]
+                    ) as? [Swift.Double?] {
+                        return value
+                    }
+                    let value = [1.0, 2.0, 3.0, nil]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_optionalDoubleArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -390,11 +489,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var doubleArray = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_doubleArrayKey
-                    ) as? [Swift.Double?]
-                    ?? [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0]
+                    ) as? [Swift.Double?] {
+                        return value
+                    }
+                    let value = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_doubleArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -423,11 +531,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var optionalBoolArray = [true, false, nil] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_optionalBoolArrayKey
-                    ) as? [Swift.Bool?]
-                    ?? [true, false, nil]
+                    ) as? [Swift.Bool?] {
+                        return value
+                    }
+                    let value = [true, false, nil]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_optionalBoolArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -455,11 +572,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var optionalStringArray = [nil, "true", "false", nil] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_optionalStringArrayKey
-                    ) as? [Swift.String?]
-                    ?? [nil, "true", "false", nil]
+                    ) as? [Swift.String?] {
+                        return value
+                    }
+                    let value = [nil, "true", "false", nil]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_optionalStringArrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -490,11 +616,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var dic = ["t": "a", "s": "b"] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_dicKey
-                    ) as? [Swift.String: Swift.String]
-                    ?? ["t": "a", "s": "b"]
+                    ) as? [Swift.String: Swift.String] {
+                        return value
+                    }
+                    let value = ["t": "a", "s": "b"]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_dicKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -522,11 +657,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var dic = [1: 3, 2: 4] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_dicKey
-                    ) as? [Swift.Int: Swift.Int]
-                    ?? [1: 3, 2: 4]
+                    ) as? [Swift.Int: Swift.Int] {
+                        return value
+                    }
+                    let value = [1: 3, 2: 4]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_dicKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -554,11 +698,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var dic = [1.0: 3.0, 2.0: 4.0] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_dicKey
-                    ) as? [Swift.Double: Swift.Double]
-                    ?? [1.0: 3.0, 2.0: 4.0]
+                    ) as? [Swift.Double: Swift.Double] {
+                        return value
+                    }
+                    let value = [1.0: 3.0, 2.0: 4.0]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_dicKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(
@@ -590,11 +743,20 @@ extension AssociatedTypeDetectionObjectTests {
             """
             var array = [[1.0], [2.0], [3.0, 4.0]] {
                 get {
-                    objc_getAssociatedObject(
+                    if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_arrayKey
-                    ) as? [[Swift.Double]]
-                    ?? [[1.0], [2.0], [3.0, 4.0]]
+                    ) as? [[Swift.Double]] {
+                        return value
+                    }
+                    let value = [[1.0], [2.0], [3.0, 4.0]]
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_arrayKey,
+                        value,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                    return value
                 }
                 set {
                     objc_setAssociatedObject(

--- a/Tests/AssociatedObjectTests/AssociatedTypeDetectionObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedTypeDetectionObjectTests.swift
@@ -38,7 +38,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? Swift.Int {
                         return value
                     }
-                    let value = 10
+                    let value: Swift.Int = 10
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_intKey,
@@ -79,7 +79,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? Swift.Double {
                         return value
                     }
-                    let value = 10.0
+                    let value: Swift.Double = 10.0
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_doubleKey,
@@ -120,7 +120,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? Swift.String {
                         return value
                     }
-                    let value = "text"
+                    let value: Swift.String = "text"
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringKey,
@@ -161,7 +161,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? Swift.Bool {
                         return value
                     }
-                    let value = false
+                    let value: Swift.Bool = false
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_boolKey,
@@ -205,7 +205,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Int] {
                         return value
                     }
-                    let value = [1, 2, 3]
+                    let value: [Swift.Int] = [1, 2, 3]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_intArrayKey,
@@ -246,7 +246,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Double] {
                         return value
                     }
-                    let value = [1.0, 2.0, 3.0]
+                    let value: [Swift.Double] = [1.0, 2.0, 3.0]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_doubleArrayKey,
@@ -287,7 +287,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Double] {
                         return value
                     }
-                    let value = [1, 1.0, 2, 2.0, 3, 3.0]
+                    let value: [Swift.Double] = [1, 1.0, 2, 2.0, 3, 3.0]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_doubleArrayKey,
@@ -328,7 +328,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Bool] {
                         return value
                     }
-                    let value = [true, false]
+                    let value: [Swift.Bool] = [true, false]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_boolArrayKey,
@@ -369,7 +369,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.String] {
                         return value
                     }
-                    let value = ["1.0", "2.0", "3.0"]
+                    let value: [Swift.String] = ["1.0", "2.0", "3.0"]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_stringArrayKey,
@@ -413,7 +413,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Int?] {
                         return value
                     }
-                    let value = [1, 1, nil, 2, 3, nil]
+                    let value: [Swift.Int?] = [1, 1, nil, 2, 3, nil]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_optionalIntArrayKey,
@@ -454,7 +454,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Double?] {
                         return value
                     }
-                    let value = [1.0, 2.0, 3.0, nil]
+                    let value: [Swift.Double?] = [1.0, 2.0, 3.0, nil]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_optionalDoubleArrayKey,
@@ -495,7 +495,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Double?] {
                         return value
                     }
-                    let value = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0]
+                    let value: [Swift.Double?] = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_doubleArrayKey,
@@ -537,7 +537,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Bool?] {
                         return value
                     }
-                    let value = [true, false, nil]
+                    let value: [Swift.Bool?] = [true, false, nil]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_optionalBoolArrayKey,
@@ -578,7 +578,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.String?] {
                         return value
                     }
-                    let value = [nil, "true", "false", nil]
+                    let value: [Swift.String?] = [nil, "true", "false", nil]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_optionalStringArrayKey,
@@ -622,7 +622,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.String: Swift.String] {
                         return value
                     }
-                    let value = ["t": "a", "s": "b"]
+                    let value: [Swift.String:Swift.String] = ["t": "a", "s": "b"]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_dicKey,
@@ -663,7 +663,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Int: Swift.Int] {
                         return value
                     }
-                    let value = [1: 3, 2: 4]
+                    let value: [Swift.Int:Swift.Int] = [1: 3, 2: 4]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_dicKey,
@@ -704,7 +704,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [Swift.Double: Swift.Double] {
                         return value
                     }
-                    let value = [1.0: 3.0, 2.0: 4.0]
+                    let value: [Swift.Double:Swift.Double] = [1.0: 3.0, 2.0: 4.0]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_dicKey,
@@ -749,7 +749,7 @@ extension AssociatedTypeDetectionObjectTests {
                     ) as? [[Swift.Double]] {
                         return value
                     }
-                    let value = [[1.0], [2.0], [3.0, 4.0]]
+                    let value: [[Swift.Double]] = [[1.0], [2.0], [3.0, 4.0]]
                     objc_setAssociatedObject(
                         self,
                         &Self.__associated_arrayKey,


### PR DESCRIPTION
Default value should set to AssociatedObject.
For example, you have a associated UIView. You don't want to recreate a new view every time you access this value.
```swift
@AssociatedObject(.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
var someView: UIView = {
    SomeCustomView()
}()
```