### PR TITLE
Fix Bug: Optional & ImplicitlyUnwrappedOptional

### DIFF
--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -178,9 +178,7 @@ extension AssociatedObjectMacro {
         policy: ExprSyntax,
         defaultValue: ExprSyntax?
     ) -> AccessorDeclSyntax {
-        let varTypeWithoutOptional = if let type = type.as(OptionalTypeSyntax.self) {
-            type.wrappedType
-        } else if let type = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+        let varTypeWithoutOptional = if let type = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
             type.wrappedType
         } else {
             type

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -135,7 +135,14 @@ extension AssociatedObjectMacro {
         policy: ExprSyntax,
         defaultValue: ExprSyntax?
     ) -> AccessorDeclSyntax {
-        AccessorDeclSyntax(
+        let varTypeWithoutOptional = if let type = type.as(OptionalTypeSyntax.self) {
+            type.wrappedType
+        } else if let type = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            type.wrappedType
+        } else {
+            type
+        }
+        return AccessorDeclSyntax(
             accessorSpecifier: .keyword(.get),
             body: CodeBlockSyntax {
                 if let defaultValue {
@@ -143,7 +150,7 @@ extension AssociatedObjectMacro {
                     if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_\(identifier.trimmed)Key
-                    ) as? \(type.trimmed) {
+                    ) as? \(varTypeWithoutOptional.trimmed) {
                         return value
                     }
                         let value: \(type.trimmed) = \(defaultValue.trimmed)
@@ -160,7 +167,7 @@ extension AssociatedObjectMacro {
                     if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_\(identifier.trimmed)Key
-                    ) as? \(type.trimmed) {
+                    ) as? \(varTypeWithoutOptional.trimmed) {
                         return value
                     }
                         return nil

--- a/Sources/AssociatedObjectPlugin/Extension/TypeSyntax+.swift
+++ b/Sources/AssociatedObjectPlugin/Extension/TypeSyntax+.swift
@@ -11,7 +11,7 @@ import SwiftSyntaxBuilder
 
 extension TypeSyntax {
     var isOptional: Bool {
-        if self.as(OptionalTypeSyntax.self) != nil {
+        if self.is(OptionalTypeSyntax.self) || self.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
             return true
         }
         if let simpleType = self.as(IdentifierTypeSyntax.self),

--- a/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
@@ -294,7 +294,7 @@ final class AssociatedObjectTests: XCTestCase {
                     objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String?
+                    ) as? String
                     ?? nil
                 }
                 set {
@@ -924,6 +924,9 @@ extension AssociatedObjectTests {
 
         item.optionalDouble = nil
         XCTAssertEqual(item.optionalDouble, nil)
+
+        item.implicitlyUnwrappedString = "hello"
+        XCTAssertEqual(item.implicitlyUnwrappedString, "hello")
     }
 
     func testSetDefaultValue() {

--- a/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
@@ -227,7 +227,41 @@ final class AssociatedObjectTests: XCTestCase {
                     if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_stringKey
-                    ) as? String? {
+                    ) as? String {
+                        return value
+                    }
+                    return nil
+                }
+                set {
+                    objc_setAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey,
+                        newValue,
+                        .OBJC_ASSOCIATION_ASSIGN
+                    )
+                }
+            }
+
+            static var __associated_stringKey: UInt8 = 0
+            """,
+            macros: macros
+        )
+    }
+    
+    func testImplicitlyUnwrappedOptionalString() throws {
+        assertMacroExpansion(
+            """
+            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            var string: String!
+            """,
+            expandedSource:
+            """
+            var string: String! {
+                get {
+                    if let value = objc_getAssociatedObject(
+                        self,
+                        &Self.__associated_stringKey
+                    ) as? String {
                         return value
                     }
                     return nil
@@ -377,7 +411,7 @@ final class AssociatedObjectTests: XCTestCase {
                     if let value = objc_getAssociatedObject(
                         self,
                         &Self.__associated_boolKey
-                    ) as? Bool? {
+                    ) as? Bool {
                         return value
                     }
                     return nil

--- a/Tests/AssociatedObjectTests/Model/ClassType.swift
+++ b/Tests/AssociatedObjectTests/Model/ClassType.swift
@@ -33,6 +33,9 @@ class ClassType {
     @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
     var optionalBool: Bool? = false
 
+    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    var implicitlyUnwrappedString: String!
+
     @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
     var intArray = [0]
 


### PR DESCRIPTION
Xcode will give this an error.
```swift
// before
@AssociatedObject(.OBJC_ASSOCIATION_COPY)
var test: String!

// expanded
var string: String! {
    get {
        if let value = objc_getAssociatedObject(
            self,
            &Self.__associated_stringKey
        ) as? String! {   // <-- This `String!` is not allowed.
            return value
        }
        return nil
    }
    set {
        objc_setAssociatedObject(
            self,
            &Self.__associated_stringKey,
            newValue,
            .OBJC_ASSOCIATION_ASSIGN
        )
    }
}
```