### PR TITLE
Support for non-apple platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,17 @@ jobs:
 
       - name: Test
         run: swift test
+
+  linux-test:
+    name: Linux Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Swift
+        uses: slashmo/install-swift@v0.4.0
+        with:
+          version: swift-5.9-RELEASE
+
+      - uses: actions/checkout@v4
+
+      - name: Test
+        run: swift test

--- a/AssociatedObject.podspec
+++ b/AssociatedObject.podspec
@@ -21,8 +21,11 @@ Pod::Spec.new do |s|
 
   s.prepare_command = 'swift build -c release && cp -f .build/release/AssociatedObjectPlugin ./Binary'
 
-  s.source_files  = "Sources/AssociatedObject/AssociatedObject.swift", 'Sources/AssociatedObjectC/**/*.{c,h,m,swift}'
+  s.source_files  = "Sources/AssociatedObject/**/*.{c,h,m,swift}", 'Sources/AssociatedObjectC/**/*.{c,h,m,swift}'
   s.swift_versions = "5.9"
+
+  # CocoaPods do not support Linux
+  # s.dependency "ObjectAssociation", "0.5.0"
 
   s.preserve_paths = ["Binary/AssociatedObjectPlugin"]
   s.pod_target_xcconfig = {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-object-association.git",
       "state" : {
-        "revision" : "1719b57842416536f68deb1df364c28577ed20f3",
-        "version" : "0.4.0"
+        "revision" : "93806cfecae1f198c894ed5585b93aff0e2d1f5a",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-object-association.git",
       "state" : {
-        "revision" : "c54aa5b34957f9b116e811a132df2ec396941316",
-        "version" : "0.3.0"
+        "revision" : "1719b57842416536f68deb1df364c28577ed20f3",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "swift-object-association",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/p-x9/swift-object-association.git",
+      "state" : {
+        "revision" : "c54aa5b34957f9b116e811a132df2ec396941316",
+        "version" : "0.3.0"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/p-x9/swift-object-association.git",
-            from: "0.3.0"
+            from: "0.4.0"
         ),
         .package(
             url: "https://github.com/pointfreeco/swift-macro-testing.git",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/p-x9/swift-object-association.git",
-            from: "0.4.0"
+            from: "0.5.0"
         ),
         .package(
             url: "https://github.com/pointfreeco/swift-macro-testing.git",

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,10 @@ let package = Package(
             from: "0.1.0"
         ),
         .package(
+            url: "https://github.com/p-x9/swift-object-association.git",
+            from: "0.3.0"
+        ),
+        .package(
             url: "https://github.com/pointfreeco/swift-macro-testing.git",
             from: "0.2.2"
         )
@@ -35,7 +39,16 @@ let package = Package(
             name: "AssociatedObject",
             dependencies: [
                 "AssociatedObjectC",
-                "AssociatedObjectPlugin"
+                "AssociatedObjectPlugin",
+                .product(
+                    name: "ObjectAssociation",
+                    package: "swift-object-association",
+                    condition: .when(
+                        platforms: [
+                            .linux, .openbsd, .windows, .android
+                        ]
+                    )
+                )
             ]
         ),
         .target(

--- a/Sources/AssociatedObject/AssociatedObject.swift
+++ b/Sources/AssociatedObject/AssociatedObject.swift
@@ -1,13 +1,25 @@
-@_exported import ObjectiveC
-
 #if canImport(AssociatedObjectC)
 @_exported import AssociatedObjectC
 #endif
 
+
+#if canImport(ObjectiveC)
+
+@_exported import ObjectiveC
+public typealias Policy = objc_AssociationPolicy
+
+#elseif canImport(ObjectAssociation)
+
+@_exported import ObjectAssociation
+public typealias Policy = swift_AssociationPolicy
+
+#endif
+
+
 @attached(peer, names: arbitrary)
 @attached(accessor)
 public macro AssociatedObject(
-    _ policy: objc_AssociationPolicy
+    _ policy: Policy
 ) = #externalMacro(
     module: "AssociatedObjectPlugin",
     type: "AssociatedObjectMacro"
@@ -16,7 +28,7 @@ public macro AssociatedObject(
 @attached(peer, names: arbitrary)
 @attached(accessor)
 public macro AssociatedObject(
-    _ policy: objc_AssociationPolicy,
+    _ policy: Policy,
     key: Any
 ) = #externalMacro(
     module: "AssociatedObjectPlugin",
@@ -25,7 +37,7 @@ public macro AssociatedObject(
 
 @attached(accessor)
 public macro _AssociatedObject(
-    _ policy: objc_AssociationPolicy
+    _ policy: Policy
 ) = #externalMacro(
     module: "AssociatedObjectPlugin",
     type: "AssociatedObjectMacro"

--- a/Sources/AssociatedObject/Extension/objc_AssociationPolicy+.swift
+++ b/Sources/AssociatedObject/Extension/objc_AssociationPolicy+.swift
@@ -6,6 +6,8 @@
 //  
 //
 
+#if canImport(ObjectiveC)
+
 import ObjectiveC
 
 /// Extension for objc_AssociationPolicy to provide a more Swift-friendly interface.
@@ -47,3 +49,5 @@ extension objc_AssociationPolicy {
         }
     }
 }
+
+#endif

--- a/Sources/AssociatedObject/Extension/swift_AssociationPolicy+.swift
+++ b/Sources/AssociatedObject/Extension/swift_AssociationPolicy+.swift
@@ -1,0 +1,43 @@
+//
+//  swift_AssociationPolicy+.swift
+//
+//
+//  Created by p-x9 on 2024/01/29.
+//  
+//
+
+#if canImport(ObjectAssociation)
+
+import ObjectAssociation
+
+/// Extension for swift_AssociationPolicy to provide a more Swift-friendly interface.
+extension swift_AssociationPolicy {
+    /// Represents the atomicity options for associated objects.
+    public enum Atomicity {
+        /// Indicates that the associated object should be stored atomically.
+        case atomic
+        /// Indicates that the associated object should be stored non-atomically.
+        case nonatomic
+    }
+
+    /// A property wrapper that corresponds to `.SWIFT_ASSOCIATION_ASSIGN` policy.
+    public static var assign: Self { .SWIFT_ASSOCIATION_ASSIGN }
+
+    /// A property wrapper that corresponds to `.SWIFT_ASSOCIATION_WEAK` policy.
+    public static var weak: Self { .SWIFT_ASSOCIATION_WEAK }
+
+    /// Create an association policy for retaining an associated object with the specified atomicity.
+    ///
+    /// - Parameter atomicity: The desired atomicity for the associated object.
+    /// - Returns: The appropriate association policy for retaining with the specified atomicity.
+    public static func retain(_ atomicity: Atomicity) -> Self {
+        switch atomicity {
+        case .atomic:
+            return .SWIFT_ASSOCIATION_RETAIN
+        case .nonatomic:
+            return .SWIFT_ASSOCIATION_RETAIN_NONATOMIC
+        }
+    }
+}
+
+#endif

--- a/Sources/AssociatedObject/functions.swift
+++ b/Sources/AssociatedObject/functions.swift
@@ -1,0 +1,50 @@
+//
+//  functions.swift
+//
+//
+//  Created by p-x9 on 2024/01/28.
+//  
+//
+
+#if canImport(ObjectiveC)
+import ObjectiveC
+#elseif canImport(ObjectAssociation)
+import ObjectAssociation
+#else
+#warning("Current platform is not supported")
+#endif
+
+
+public func getAssociatedObject(
+    _ object: AnyObject,
+    _ key: UnsafeRawPointer
+) -> Any? {
+#if canImport(ObjectiveC)
+    objc_getAssociatedObject(object, key)
+#elseif canImport(ObjectAssociation)
+    ObjectAssociation.getAssociatedObject(object, key)
+#endif
+}
+
+
+public func setAssociatedObject(
+    _ object: AnyObject,
+    _ key: UnsafeRawPointer,
+    _ value: Any?,
+    _ policy: Policy = .retain(.nonatomic)
+) {
+#if canImport(ObjectiveC)
+    objc_setAssociatedObject(
+        object,
+        key,
+        value,
+        policy
+    )
+#elseif canImport(ObjectAssociation)
+    ObjectAssociation.setAssociatedObject(
+        object,
+        key,
+        value
+    )
+#endif
+}

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -78,7 +78,7 @@ extension AssociatedObjectMacro: PeerMacro {
             let flagName = "__associated_\(identifier.trimmed)IsSet"
             let flagDecl = VariableDeclSyntax(
                 attributes: [
-                    .attribute("@_AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)")
+                    .attribute("@_AssociatedObject(.retain(.nonatomic))")
                 ],
                 bindingSpecifier: .identifier("var"),
                 bindings: PatternBindingListSyntax {
@@ -180,7 +180,7 @@ extension AssociatedObjectMacro: AccessorMacro {
             return []
         }
 
-        var policy: ExprSyntax = ".OBJC_ASSOCIATION_RETAIN_NONATOMIC"
+        var policy: ExprSyntax = ".retain(.nonatomic)"
         if let firstElement = arguments.first?.expression,
            let specifiedPolicy = firstElement.as(ExprSyntax.self) {
             policy = specifiedPolicy
@@ -241,7 +241,7 @@ extension AssociatedObjectMacro {
                     """
                     if !self.__associated_\(identifier.trimmed)IsSet {
                         let value: \(type.trimmed) = \(defaultValue.trimmed)
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             \(associatedKey),
                             value,
@@ -250,7 +250,7 @@ extension AssociatedObjectMacro {
                         self.__associated_\(identifier.trimmed)IsSet = true
                         return value
                     } else {
-                        return objc_getAssociatedObject(
+                        return getAssociatedObject(
                             self,
                             \(associatedKey)
                         ) as! \(typeWithoutOptional.trimmed)
@@ -258,14 +258,14 @@ extension AssociatedObjectMacro {
                     """
                 } else if let defaultValue {
                     """
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         \(associatedKey)
                     ) as? \(typeWithoutOptional.trimmed) {
                         return value
                     } else {
                         let value: \(type.trimmed) = \(defaultValue.trimmed)
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             \(associatedKey),
                             value,
@@ -276,7 +276,7 @@ extension AssociatedObjectMacro {
                     """
                 } else {
                     """
-                    objc_getAssociatedObject(
+                    getAssociatedObject(
                         self,
                         \(associatedKey)
                     ) as? \(typeWithoutOptional.trimmed)
@@ -325,7 +325,7 @@ extension AssociatedObjectMacro {
                 }
 
                 """
-                objc_setAssociatedObject(
+                setAssociatedObject(
                     self,
                     \(associatedKey),
                     newValue,

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -176,15 +176,18 @@ extension AssociatedObjectMacro: AccessorMacro {
             return []
         }
 
-        guard case let .argumentList(arguments) = node.arguments,
-              let firstElement = arguments.first?.expression,
-              let policy = firstElement.as(ExprSyntax.self) else {
+        guard case let .argumentList(arguments) = node.arguments else {
             return []
         }
 
+        var policy: ExprSyntax = ".OBJC_ASSOCIATION_RETAIN_NONATOMIC"
+        if let firstElement = arguments.first?.expression,
+           let specifiedPolicy = firstElement.as(ExprSyntax.self) {
+            policy = specifiedPolicy
+        }
+
         var associatedKey: ExprSyntax = "Self.__associated_\(identifier.trimmed)Key"
-        if case let .argumentList(arguments) = node.arguments,
-           let element = arguments.first(where: { $0.label?.text == "key" }),
+        if let element = arguments.first(where: { $0.label?.text == "key" }),
            let customKey = element.expression.as(ExprSyntax.self) {
             // Provide store key from outside the macro
             associatedKey = "&\(customKey)"
@@ -225,7 +228,7 @@ extension AssociatedObjectMacro {
         policy: ExprSyntax,
         defaultValue: ExprSyntax?
     ) -> AccessorDeclSyntax {
-        let varTypeWithoutOptional = if let type = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+        let typeWithoutOptional = if let type = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
             type.wrappedType
         } else {
             type
@@ -234,51 +237,49 @@ extension AssociatedObjectMacro {
         return AccessorDeclSyntax(
             accessorSpecifier: .keyword(.get),
             body: CodeBlockSyntax {
-                if let defaultValue {
-                    if type.isOptional {
-                        """
-                        if !self.__associated_\(identifier.trimmed)IsSet {
-                            let value: \(type.trimmed) = \(defaultValue.trimmed)
-                            objc_setAssociatedObject(
-                                self,
-                                \(associatedKey),
-                                value,
-                                \(policy.trimmed)
-                            )
-                            self.__associated_\(identifier.trimmed)IsSet = true
-                            return value
-                        } else {
-                            return objc_getAssociatedObject(
-                                self,
-                                \(associatedKey)
-                            ) as! \(varTypeWithoutOptional.trimmed)
-                        }
-                        """
+                if let defaultValue, type.isOptional {
+                    """
+                    if !self.__associated_\(identifier.trimmed)IsSet {
+                        let value: \(type.trimmed) = \(defaultValue.trimmed)
+                        objc_setAssociatedObject(
+                            self,
+                            \(associatedKey),
+                            value,
+                            \(policy.trimmed)
+                        )
+                        self.__associated_\(identifier.trimmed)IsSet = true
+                        return value
                     } else {
-                        """
-                        if let value = objc_getAssociatedObject(
+                        return objc_getAssociatedObject(
                             self,
                             \(associatedKey)
-                        ) as? \(varTypeWithoutOptional.trimmed) {
-                            return value
-                        } else {
-                            let value: \(type.trimmed) = \(defaultValue.trimmed)
-                            objc_setAssociatedObject(
-                                self,
-                                \(associatedKey),
-                                value,
-                                \(policy.trimmed)
-                            )
-                            return value
-                        }
-                        """
+                        ) as! \(typeWithoutOptional.trimmed)
                     }
+                    """
+                } else if let defaultValue {
+                    """
+                    if let value = objc_getAssociatedObject(
+                        self,
+                        \(associatedKey)
+                    ) as? \(typeWithoutOptional.trimmed) {
+                        return value
+                    } else {
+                        let value: \(type.trimmed) = \(defaultValue.trimmed)
+                        objc_setAssociatedObject(
+                            self,
+                            \(associatedKey),
+                            value,
+                            \(policy.trimmed)
+                        )
+                        return value
+                    }
+                    """
                 } else {
                     """
                     objc_getAssociatedObject(
                         self,
                         \(associatedKey)
-                    ) as? \(varTypeWithoutOptional.trimmed)
+                    ) as? \(typeWithoutOptional.trimmed)
                     ?? \(defaultValue ?? "nil")
                     """
                 }

--- a/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
@@ -19,35 +19,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testString() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.atomic))
             var string: String = "text"
             """
         } expansion: {
             """
             var string: String = "text" {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.atomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.atomic)
                     )
                 }
             }
@@ -62,35 +62,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testInt() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var int: Int = 5
             """
         } expansion: {
             """
             var int: Int = 5 {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_intKey
                     ) as? Int {
                         return value
                     } else {
                         let value: Int = 5
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_intKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_intKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -105,35 +105,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testFloat() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var float: Float = 5.0
             """
         } expansion: {
             """
             var float: Float = 5.0 {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_floatKey
                     ) as? Float {
                         return value
                     } else {
                         let value: Float = 5.0
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_floatKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_floatKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -148,35 +148,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testDouble() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var double: Double = 5.0
             """
         } expansion: {
             """
             var double: Double = 5.0 {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_doubleKey
                     ) as? Double {
                         return value
                     } else {
                         let value: Double = 5.0
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_doubleKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_doubleKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -191,35 +191,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testStringWithOtherPolicy() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_COPY)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String = "text"
             """
         } expansion: {
             """
             var string: String = "text" {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_COPY
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_COPY
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -234,25 +234,25 @@ final class AssociatedObjectTests: XCTestCase {
     func testOptionalString() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String?
             """
         } expansion: {
             """
             var string: String? {
                 get {
-                    objc_getAssociatedObject(
+                    getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String?
                     ?? nil
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -267,25 +267,25 @@ final class AssociatedObjectTests: XCTestCase {
     func testOptionalGenericsString() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: Optional<String>
             """
         } expansion: {
             """
             var string: Optional<String> {
                 get {
-                    objc_getAssociatedObject(
+                    getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? Optional<String>
                     ?? nil
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -300,25 +300,25 @@ final class AssociatedObjectTests: XCTestCase {
     func testImplicitlyUnwrappedOptionalString() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String!
             """
         } expansion: {
             """
             var string: String! {
                 get {
-                    objc_getAssociatedObject(
+                    getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String
                     ?? nil
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -333,7 +333,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testOptionalStringWithInitialValue() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String? = "hello"
             """
         } expansion: {
@@ -342,27 +342,27 @@ final class AssociatedObjectTests: XCTestCase {
                 get {
                     if !self.__associated_stringIsSet {
                         let value: String? = "hello"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         self.__associated_stringIsSet = true
                         return value
                     } else {
-                        return objc_getAssociatedObject(
+                        return getAssociatedObject(
                             self,
                             Self.__associated_stringKey
                         ) as! String?
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -371,7 +371,7 @@ final class AssociatedObjectTests: XCTestCase {
                 _associated_object_key()
             }
 
-            @_AssociatedObject(.OBJC_ASSOCIATION_ASSIGN) var __associated_stringIsSet: Bool = false
+            @_AssociatedObject(.retain(.nonatomic)) var __associated_stringIsSet: Bool = false
 
             @inline(never) static var __associated___associated_stringIsSetKey: UnsafeRawPointer {
                 _associated_object_key()
@@ -383,35 +383,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testBool() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var bool: Bool = false
             """
         } expansion: {
             """
             var bool: Bool = false {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_boolKey
                     ) as? Bool {
                         return value
                     } else {
                         let value: Bool = false
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_boolKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_boolKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -426,35 +426,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testIntArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var intArray: [Int] = [1, 2, 3]
             """
         } expansion: {
             """
             var intArray: [Int] = [1, 2, 3] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_intArrayKey
                     ) as? [Int] {
                         return value
                     } else {
                         let value: [Int] = [1, 2, 3]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_intArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_intArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -469,25 +469,25 @@ final class AssociatedObjectTests: XCTestCase {
     func testOptionalBool() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var bool: Bool?
             """
         } expansion: {
             """
             var bool: Bool? {
                 get {
-                    objc_getAssociatedObject(
+                    getAssociatedObject(
                         self,
                         Self.__associated_boolKey
                     ) as? Bool?
                     ?? nil
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_boolKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -502,35 +502,35 @@ final class AssociatedObjectTests: XCTestCase {
     func testDictionary() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var dic: [String: String] = ["t": "a"]
             """
         } expansion: {
             """
             var dic: [String: String] = ["t": "a"] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_dicKey
                     ) as? [String: String] {
                         return value
                     } else {
                         let value: [String: String] = ["t": "a"]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_dicKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_dicKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -545,7 +545,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testWillSet() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String = "text" {
                 willSet {
                     print("willSet: old", string)
@@ -561,18 +561,18 @@ final class AssociatedObjectTests: XCTestCase {
                     print("willSet: new", newValue)
                 }
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
@@ -585,11 +585,11 @@ final class AssociatedObjectTests: XCTestCase {
                     }
                     willSet(newValue)
 
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -604,7 +604,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testDidSet() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String = "text" {
                 didSet {
                     print("didSet: old", oldValue)
@@ -618,18 +618,18 @@ final class AssociatedObjectTests: XCTestCase {
                     print("didSet: old", oldValue)
                 }
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
@@ -637,11 +637,11 @@ final class AssociatedObjectTests: XCTestCase {
 
                 set {
                     let oldValue = string
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
 
                     let didSet: (String) -> Void = { [self] oldValue in
@@ -661,7 +661,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testWillSetAndDidSet() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String = "text" {
                 willSet {
                     print("willSet: old", string)
@@ -683,18 +683,18 @@ final class AssociatedObjectTests: XCTestCase {
                     print("didSet: old", oldValue)
                 }
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
@@ -708,11 +708,11 @@ final class AssociatedObjectTests: XCTestCase {
                     willSet(newValue)
 
                     let oldValue = string
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
 
                     let didSet: (String) -> Void = { [self] oldValue in
@@ -732,7 +732,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testWillSetWithArgument() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String = "text" {
                 willSet(new) {
                     print("willSet: old", string)
@@ -748,18 +748,18 @@ final class AssociatedObjectTests: XCTestCase {
                     print("willSet: new", new)
                 }
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
@@ -772,11 +772,11 @@ final class AssociatedObjectTests: XCTestCase {
                     }
                     willSet(newValue)
 
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -791,7 +791,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testDidSetWithArgument() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String = "text" {
                 didSet(old) {
                     print("didSet: old", old)
@@ -805,18 +805,18 @@ final class AssociatedObjectTests: XCTestCase {
                     print("didSet: old", old)
                 }
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
@@ -824,11 +824,11 @@ final class AssociatedObjectTests: XCTestCase {
 
                 set {
                     let oldValue = string
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
 
                     let didSet: (String) -> Void = { [self] old in
@@ -855,14 +855,14 @@ final class AssociatedObjectTests: XCTestCase {
             """
             var string: String = "text" {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
@@ -872,7 +872,7 @@ final class AssociatedObjectTests: XCTestCase {
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
@@ -892,12 +892,12 @@ final class AssociatedObjectTests: XCTestCase {
     func testDiagnosticsDeclarationType() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             struct Item {}
             """
         } diagnostics: {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             ╰─ 🛑 `@AssociatedObject` must be attached to the property declaration.
             struct Item {}
             """
@@ -907,7 +907,7 @@ final class AssociatedObjectTests: XCTestCase {
     func testDiagnosticsGetterAndSetter() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String? {
                 get { "" }
                 set {}
@@ -915,7 +915,7 @@ final class AssociatedObjectTests: XCTestCase {
             """
         } diagnostics: {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String? {
                 get { "" }
                 set {}
@@ -929,12 +929,12 @@ final class AssociatedObjectTests: XCTestCase {
     func testDiagnosticsInitialValue() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string: String
             """
         } diagnostics: {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             ╰─ 🛑 Initial values must be specified when using `@AssociatedObject`.
             var string: String
             """
@@ -944,12 +944,12 @@ final class AssociatedObjectTests: XCTestCase {
     func testDiagnosticsSpecifyType() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string = ["text", 123]
             """
         } diagnostics: {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string = ["text", 123]
                 ┬─────
                 ├─ 🛑 Specify a type explicitly when using `@AssociatedObject`.
@@ -961,14 +961,14 @@ final class AssociatedObjectTests: XCTestCase {
     func testDiagnosticsInvalidCustomKey() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN, key: "key")
+            @AssociatedObject(.retain(.nonatomic), key: "key")
             var string = "string"
             """
         } diagnostics: {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN, key: "key")
-                                                        ┬─────────
-                                                        ╰─ 🛑 customKey specification is invalid.
+            @AssociatedObject(.retain(.nonatomic), key: "key")
+                                                   ┬─────────
+                                                   ╰─ 🛑 customKey specification is invalid.
             var string = "string"
             """
         }
@@ -979,35 +979,35 @@ extension AssociatedObjectTests {
     func testCustomStoreKey() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN, key: key)
+            @AssociatedObject(.retain(.nonatomic), key: key)
             var string: String = "text"
             """
          } expansion: {
             """
             var string: String = "text" {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         &key
                     ) as? String {
                         return value
                     } else {
                         let value: String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             &key,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         &key,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -1030,8 +1030,8 @@ extension AssociatedObjectTests {
         item.implicitlyUnwrappedString = nil
         XCTAssertEqual(item.implicitlyUnwrappedString, nil)
 
-        item.implicitlyUnwrappedString = "modified"
-        XCTAssertEqual(item.implicitlyUnwrappedString, "modified")
+        item.implicitlyUnwrappedString = "modified hello"
+        XCTAssertEqual(item.implicitlyUnwrappedString, "modified hello")
     }
 
     func testSetDefaultValue() {

--- a/Tests/AssociatedObjectTests/AssociatedTypeDetectionObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedTypeDetectionObjectTests.swift
@@ -31,35 +31,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionInt() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var int = 10
             """
         } expansion: {
             """
             var int = 10 {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_intKey
                     ) as? Swift.Int {
                         return value
                     } else {
                         let value: Swift.Int = 10
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_intKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_intKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -74,35 +74,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionDouble() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var double = 10.0
             """
         } expansion: {
             """
             var double = 10.0 {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_doubleKey
                     ) as? Swift.Double {
                         return value
                     } else {
                         let value: Swift.Double = 10.0
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_doubleKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_doubleKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -117,35 +117,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionString() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var string = "text"
             """
         } expansion: {
             """
             var string = "text" {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringKey
                     ) as? Swift.String {
                         return value
                     } else {
                         let value: Swift.String = "text"
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -160,35 +160,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionBool() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var bool = false
             """
         } expansion: {
             """
             var bool = false {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_boolKey
                     ) as? Swift.Bool {
                         return value
                     } else {
                         let value: Swift.Bool = false
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_boolKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_boolKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -206,35 +206,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionIntArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var intArray = [1, 2, 3]
             """
         } expansion: {
             """
             var intArray = [1, 2, 3] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_intArrayKey
                     ) as? [Swift.Int] {
                         return value
                     } else {
                         let value: [Swift.Int] = [1, 2, 3]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_intArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_intArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -249,35 +249,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionDoubleArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var doubleArray = [1.0, 2.0, 3.0]
             """
         } expansion: {
             """
             var doubleArray = [1.0, 2.0, 3.0] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_doubleArrayKey
                     ) as? [Swift.Double] {
                         return value
                     } else {
                         let value: [Swift.Double] = [1.0, 2.0, 3.0]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_doubleArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_doubleArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -292,35 +292,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionIntAndDoubleArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var doubleArray = [1, 1.0, 2, 2.0, 3, 3.0]
             """
         } expansion: {
             """
             var doubleArray = [1, 1.0, 2, 2.0, 3, 3.0] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_doubleArrayKey
                     ) as? [Swift.Double] {
                         return value
                     } else {
                         let value: [Swift.Double] = [1, 1.0, 2, 2.0, 3, 3.0]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_doubleArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_doubleArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -335,35 +335,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionBoolArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var boolArray = [true, false]
             """
         } expansion: {
             """
             var boolArray = [true, false] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_boolArrayKey
                     ) as? [Swift.Bool] {
                         return value
                     } else {
                         let value: [Swift.Bool] = [true, false]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_boolArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_boolArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -378,35 +378,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionStringArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var stringArray = ["1.0", "2.0", "3.0"]
             """
         } expansion: {
             """
             var stringArray = ["1.0", "2.0", "3.0"] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_stringArrayKey
                     ) as? [Swift.String] {
                         return value
                     } else {
                         let value: [Swift.String] = ["1.0", "2.0", "3.0"]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_stringArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_stringArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -424,35 +424,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionOptionalIntArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var optionalIntArray = [1, 1, nil, 2, 3, nil]
             """
         } expansion: {
             """
             var optionalIntArray = [1, 1, nil, 2, 3, nil] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_optionalIntArrayKey
                     ) as? [Swift.Int?] {
                         return value
                     } else {
                         let value: [Swift.Int?] = [1, 1, nil, 2, 3, nil]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_optionalIntArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_optionalIntArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -467,35 +467,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionOptionalDoubleArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var optionalDoubleArray = [1.0, 2.0, 3.0, nil]
             """
         } expansion: {
             """
             var optionalDoubleArray = [1.0, 2.0, 3.0, nil] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_optionalDoubleArrayKey
                     ) as? [Swift.Double?] {
                         return value
                     } else {
                         let value: [Swift.Double?] = [1.0, 2.0, 3.0, nil]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_optionalDoubleArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_optionalDoubleArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -510,35 +510,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionOptionalIntAndDoubleArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var doubleArray = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0]
             """
         } expansion: {
             """
             var doubleArray = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_doubleArrayKey
                     ) as? [Swift.Double?] {
                         return value
                     } else {
                         let value: [Swift.Double?] = [nil, 1, 1.0, nil, 2, 2.0, nil, 3, 3.0]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_doubleArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_doubleArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -554,35 +554,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionOptionalBoolArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var optionalBoolArray = [true, false, nil]
             """
         } expansion: {
             """
             var optionalBoolArray = [true, false, nil] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_optionalBoolArrayKey
                     ) as? [Swift.Bool?] {
                         return value
                     } else {
                         let value: [Swift.Bool?] = [true, false, nil]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_optionalBoolArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_optionalBoolArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -597,35 +597,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionOptionalStringArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var optionalStringArray = [nil, "true", "false", nil]
             """
         } expansion: {
             """
             var optionalStringArray = [nil, "true", "false", nil] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_optionalStringArrayKey
                     ) as? [Swift.String?] {
                         return value
                     } else {
                         let value: [Swift.String?] = [nil, "true", "false", nil]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_optionalStringArrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_optionalStringArrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -643,35 +643,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionStringDictionary() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var dic = ["t": "a", "s": "b"]
             """
         } expansion: {
             """
             var dic = ["t": "a", "s": "b"] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_dicKey
                     ) as? [Swift.String: Swift.String] {
                         return value
                     } else {
                         let value: [Swift.String: Swift.String] = ["t": "a", "s": "b"]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_dicKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_dicKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -686,35 +686,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionIntDictionary() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var dic = [1: 3, 2: 4]
             """
         } expansion: {
             """
             var dic = [1: 3, 2: 4] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_dicKey
                     ) as? [Swift.Int: Swift.Int] {
                         return value
                     } else {
                         let value: [Swift.Int: Swift.Int] = [1: 3, 2: 4]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_dicKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_dicKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -729,35 +729,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetectionDoubleDictionary() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var dic = [1.0: 3.0, 2.0: 4.0]
             """
         } expansion: {
             """
             var dic = [1.0: 3.0, 2.0: 4.0] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_dicKey
                     ) as? [Swift.Double: Swift.Double] {
                         return value
                     } else {
                         let value: [Swift.Double: Swift.Double] = [1.0: 3.0, 2.0: 4.0]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_dicKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_dicKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }
@@ -776,35 +776,35 @@ extension AssociatedTypeDetectionObjectTests {
     func testTypeDetection2DimensionDoubleArray() throws {
         assertMacro {
             """
-            @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+            @AssociatedObject(.retain(.nonatomic))
             var array = [[1.0], [2.0], [3.0, 4.0]]
             """
         } expansion: {
             """
             var array = [[1.0], [2.0], [3.0, 4.0]] {
                 get {
-                    if let value = objc_getAssociatedObject(
+                    if let value = getAssociatedObject(
                         self,
                         Self.__associated_arrayKey
                     ) as? [[Swift.Double]] {
                         return value
                     } else {
                         let value: [[Swift.Double]] = [[1.0], [2.0], [3.0, 4.0]]
-                        objc_setAssociatedObject(
+                        setAssociatedObject(
                             self,
                             Self.__associated_arrayKey,
                             value,
-                            .OBJC_ASSOCIATION_ASSIGN
+                            .retain(.nonatomic)
                         )
                         return value
                     }
                 }
                 set {
-                    objc_setAssociatedObject(
+                    setAssociatedObject(
                         self,
                         Self.__associated_arrayKey,
                         newValue,
-                        .OBJC_ASSOCIATION_ASSIGN
+                        .retain(.nonatomic)
                     )
                 }
             }

--- a/Tests/AssociatedObjectTests/Model/ClassType.swift
+++ b/Tests/AssociatedObjectTests/Model/ClassType.swift
@@ -9,58 +9,58 @@
 import AssociatedObject
 
 class ClassType {
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var int = 0
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var double = 0.0
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var string = ""
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var bool = false
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var optionalInt: Int?
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var optionalDouble: Double? = 123.4
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var optionalString: String?
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var optionalBool: Bool? = false
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var implicitlyUnwrappedString: String!
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var intArray = [0]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var doubleArray = [0.0, 1]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var stringArray = [""]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var boolArray = [nil, false]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var optionalIntArray = [0, nil]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var optionalDoubleArray = [0.0, nil, 1]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var optionalStringArray = [nil, ""]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_ASSIGN)
+    @AssociatedObject(.retain(.nonatomic))
     var optionalBoolArray = [false, nil]
 
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN)
+    @AssociatedObject(.retain(.atomic))
     var classType: ClassType2 = {
         .init()
     }()
@@ -71,7 +71,7 @@ class ClassType2 {}
 protocol ProtocolType: AnyObject {}
 
 extension ProtocolType {
-    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    @AssociatedObject(.retain(.nonatomic))
     var definedInProtocol = "hello"
 }
 


### PR DESCRIPTION
- Modified key generation method
- Use the [`ObjectAssociation`](https://github.com/p-x9/swift-object-association) library implementation in non-apple platform.
  (Instead of Objective-C runtime)