### PR TITLE
Fix 'duplicate symbol `__associated_object_key`' error

### DIFF
--- a/Sources/AssociatedObjectC/associated_object_key.c
+++ b/Sources/AssociatedObjectC/associated_object_key.c
@@ -1,1 +1,6 @@
+#include "include/associated_object_key.h"
 
+NOINLINE
+const void *_associated_object_key() {
+    return get_return_address();
+}

--- a/Sources/AssociatedObjectC/include/associated_object_key.h
+++ b/Sources/AssociatedObjectC/include/associated_object_key.h
@@ -31,9 +31,6 @@
 #define NOINLINE
 #endif
 
-NOINLINE
-const void *_associated_object_key() {
-    return get_return_address();
-}
+const void *_associated_object_key();
 
 #endif /* associated_object_key_h */


### PR DESCRIPTION
closes #34 