### PR TITLE
fix optional type set before get

### DIFF
--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -208,7 +208,8 @@ extension AssociatedObjectMacro: AccessorMacro {
                 identifier: identifier,
                 type: type,
                 policy: policy,
-                associatedKey: associatedKey,
+                associatedKey: associatedKey, 
+                hasDefaultValue: defaultValue != nil,
                 willSet: binding.willSet,
                 didSet: binding.didSet
             )
@@ -306,6 +307,7 @@ extension AssociatedObjectMacro {
         type: TypeSyntax,
         policy: ExprSyntax,
         associatedKey: ExprSyntax,
+        hasDefaultValue: Bool,
         `willSet`: AccessorDeclSyntax?,
         `didSet`: AccessorDeclSyntax?
     ) -> AccessorDeclSyntax {
@@ -328,14 +330,26 @@ extension AssociatedObjectMacro {
                     "let oldValue = \(identifier)"
                 }
 
-                """
-                setAssociatedObject(
-                    self,
-                    \(associatedKey),
-                    newValue,
-                    \(policy)
-                )
-                """
+                if type.isOptional, hasDefaultValue {
+                    """
+                    setAssociatedObject(
+                        self,
+                        \(associatedKey),
+                        newValue,
+                        \(policy)
+                    )
+                        self.__associated_\(identifier.trimmed)IsSet = true
+                    """
+                } else {
+                    """
+                    setAssociatedObject(
+                        self,
+                        \(associatedKey),
+                        newValue,
+                        \(policy)
+                    )
+                    """
+                }
 
                 if let didSet = `didSet`,
                    let body = didSet.body {

--- a/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
+++ b/Sources/AssociatedObjectPlugin/AssociatedObjectMacro.swift
@@ -330,24 +330,17 @@ extension AssociatedObjectMacro {
                     "let oldValue = \(identifier)"
                 }
 
+                """
+                setAssociatedObject(
+                    self,
+                    \(associatedKey),
+                    newValue,
+                    \(policy)
+                )
+                """
                 if type.isOptional, hasDefaultValue {
                     """
-                    setAssociatedObject(
-                        self,
-                        \(associatedKey),
-                        newValue,
-                        \(policy)
-                    )
-                        self.__associated_\(identifier.trimmed)IsSet = true
-                    """
-                } else {
-                    """
-                    setAssociatedObject(
-                        self,
-                        \(associatedKey),
-                        newValue,
-                        \(policy)
-                    )
+                    self.__associated_\(identifier.trimmed)IsSet = true
                     """
                 }
 

--- a/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
+++ b/Tests/AssociatedObjectTests/AssociatedObjectTests.swift
@@ -385,6 +385,7 @@ final class AssociatedObjectTests: XCTestCase {
                         newValue,
                         .retain(.nonatomic)
                     )
+                    self.__associated_stringIsSet = true
                 }
             }
 


### PR DESCRIPTION
When we have a optional type var with default value. We may set it before call get. So the value will change to the default Value.
```swift
@AssociatedObject(.retain(.atomic))
var string: String? = "text"

string = "abc"
print(string) // => text ❌
```